### PR TITLE
Add a `skip_connect` option to avoid making a database connection on initialization

### DIFF
--- a/lib/tiny_tds/client.rb
+++ b/lib/tiny_tds/client.rb
@@ -55,9 +55,13 @@ module TinyTds
       opts[:encoding] = opts[:encoding].nil? || opts[:encoding].casecmp('utf8').zero? ? 'UTF-8' : opts[:encoding].upcase
       opts[:port] ||= 1433
       opts[:dataserver] = "#{opts[:host]}:#{opts[:port]}" if opts[:dataserver].to_s.empty?
+      
       forced_integer_keys = [:login_timeout, :port, :timeout]
       forced_integer_keys.each { |k| opts[k] = opts[k].to_i if opts[k] }
-      connect(opts)
+      
+      unless opts[:skip_connect]
+        connect(opts)
+      end
     end
 
     def tds_73?


### PR DESCRIPTION
#### Todo

- [x] add `:skip_connect` init opt
- [ ] add a test for the option
- [ ] add a test for any offline instance methods we care to validate, so at least `escape`
- [ ] update readme

#### Notes

This enables creating a TinyTds::Client instance without an actual database connection. Normally this isn't useful, *except* for when you want to call `escape` offline, such as for automated testing or preparing SQL statements outside of the context of a database.